### PR TITLE
Test pymatgen based parser with broken xml

### DIFF
--- a/aiida_vasp/data/pymatgen/vasprun.py
+++ b/aiida_vasp/data/pymatgen/vasprun.py
@@ -24,8 +24,19 @@ class VasprunToAiida(object):
         """
         The structure at the last recorded ionic step
         """
-        return get_data_node(
-            'structure', pymatgen=self.vasprun_obj.structures[-1])
+        last_structure = self.vasprun_obj.structures[-1]
+        return self.final_structure or get_data_node(
+            'structure', pymatgen=last_structure)
+
+    @property
+    def final_structure(self):
+        """
+        The final structure after all calculations
+        """
+        final_structure = getattr(self.vasprun_obj, 'final_structure', None)
+        if not final_structure:
+            return None
+        return get_data_node('structure', pymatgen=final_structure)
 
 
 @dbenv

--- a/aiida_vasp/parsers/tests/test_pymatgen_parser.py
+++ b/aiida_vasp/parsers/tests/test_pymatgen_parser.py
@@ -74,9 +74,9 @@ def test_structure_result(parse_result):
 
 
 @pytest.mark.parametrize(
-    ['vasprun_path', 'parse_result'], [(2331, None)], indirect=True)
-def test_broken_vasprun(parse_result, recwarn):
-    """Test that slightly truncated vasp run can be read and warnings are emitted"""
+    ['vasprun_path', 'parse_result'], [(2331, False)], indirect=True)
+def test_slightly_broken_vasprun(parse_result, recwarn):
+    """Test that truncated vasprun (after one ionic step) can be read and warnings are emitted"""
     success, nodes = parse_result()
     nodes = dict(nodes)
     assert success

--- a/aiida_vasp/parsers/tests/test_pymatgen_parser.py
+++ b/aiida_vasp/parsers/tests/test_pymatgen_parser.py
@@ -3,6 +3,7 @@
 import os
 
 import pytest
+from aiida.common.exceptions import ParsingError
 
 from aiida_vasp.parsers.pymatgen_vasp import PymatgenParser
 from aiida_vasp.utils.fixtures import *
@@ -17,8 +18,21 @@ def data_path(*args):
     return path
 
 
-@pytest.fixture()
-def parse_result(aiida_env):
+@pytest.fixture(params=[-1])
+def vasprun_path(request, tmpdir):
+    """Truncate vasprun.xml at the given line number and parse"""
+    original_path = data_path('phonondb', 'vasprun.xml')
+    if request.param == -1:
+        return original_path
+    truncated_path = tmpdir.join('vasprun.xml')
+    with open(original_path, 'r') as original_fo:
+        truncated_content = '\n'.join(original_fo.readlines()[:request.param])
+    truncated_path.write(truncated_content)
+    return str(truncated_path)
+
+
+@pytest.fixture(params=[None])
+def parse_result(request, aiida_env, vasprun_path):
     """
     Result of parsing a retrieved calculation (emulated)
 
@@ -31,26 +45,48 @@ def parse_result(aiida_env):
     calc.use_settings(
         DataFactory('parameter')(dict={
             'pymatgen_parser': {
-                'parse_potcar_file': False
+                'parse_potcar_file': False,
+                'exception_on_bad_xml': request.param
             }
         }))
     parser = PymatgenParser(calc=calc)
     retrieved = DataFactory('folder')()
-    retrieved.add_path(data_path('phonondb', 'vasprun.xml'), '')
-    result = parser.parse_with_retrieved({'retrieved': retrieved})
-    assert result[0]
-    return result
+    retrieved.add_path(vasprun_path, '')
+
+    def parse():
+        return parser.parse_with_retrieved({'retrieved': retrieved})
+
+    return parse
 
 
 def test_kpoints_result(parse_result):
     from aiida.orm import DataFactory
-    _, nodes = parse_result
-    assert isinstance([n for n in nodes if n[0] == 'kpoints'][0][1],
-                      DataFactory('array.kpoints'))
+    _, nodes = parse_result()
+    nodes = dict(nodes)
+    assert isinstance(nodes['kpoints'], DataFactory('array.kpoints'))
 
 
 def test_structure_result(parse_result):
     from aiida.orm import DataFactory
-    _, nodes = parse_result
-    assert isinstance([n for n in nodes if n[0] == 'structure'][0][1],
-                      DataFactory('structure'))
+    _, nodes = parse_result()
+    nodes = dict(nodes)
+    assert isinstance(nodes['structure'], DataFactory('structure'))
+
+
+@pytest.mark.parametrize(
+    ['vasprun_path', 'parse_result'], [(2331, None)], indirect=True)
+def test_broken_vasprun(parse_result, recwarn):
+    """Test that slightly truncated vasp run can be read and warnings are emitted"""
+    success, nodes = parse_result()
+    nodes = dict(nodes)
+    assert success
+    assert 'kpoints' in nodes
+    assert 'structure' in nodes
+    assert len(recwarn) >= 1
+
+
+@pytest.mark.parametrize(
+    ['vasprun_path', 'parse_result'], [(2331, True)], indirect=True)
+def test_broken_vasprun_exception(parse_result):
+    with pytest.raises(ParsingError):
+        _ = parse_result()


### PR DESCRIPTION
fix #35 
* Add a test for the case of a vasprun.xml that is truncated after first ionic step
* Add some documentation of limitation that a complete ionic step must be in the `vasprun.xml`
* Add `final_structure` property to `VasprunToAiida`