### PR TITLE
Add support for parsing 'repeated' values

### DIFF
--- a/aiida_vasp/backendtests/data/INCAR
+++ b/aiida_vasp/backendtests/data/INCAR
@@ -1,4 +1,5 @@
 GGA = PE
 GGA_COMPAT = .False.
 LORBIT = 11
+MAGMOM = 60*0.0
 SIGMA = 0.5

--- a/aiida_vasp/io/tests/test_incar.py
+++ b/aiida_vasp/io/tests/test_incar.py
@@ -42,7 +42,7 @@ def test_example_incar():
     assert isinstance(incar_dict['encut'], float)
 
     assert incar_dict['bmix'] == 2.0
-    assert isinstance(incar_dict['bmix'], int)
+    assert isinstance(incar_dict['bmix'], float)
 
     assert incar_dict['nelmin'] == 0
     assert incar_dict['nelmdl'] == 3

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -41,7 +41,7 @@ def localhost(aiida_env, localhost_dir):
 
 @pytest.fixture()
 def vasp_params(aiida_env):
-    incar_io = IncarIo(incar_dict={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5})
+    incar_io = IncarIo(incar_dict={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30*2*0.'})
     return incar_io.get_param_node()
 
 

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -41,7 +41,7 @@ def localhost(aiida_env, localhost_dir):
 
 @pytest.fixture()
 def vasp_params(aiida_env):
-    incar_io = IncarIo(incar_dict={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30*2*0.'})
+    incar_io = IncarIo(incar_dict={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.'})
     return incar_io.get_param_node()
 
 


### PR DESCRIPTION
Fixes #70.

The repeated values are of the form ``int*int*..*value``, as described in http://cms.mpi.univie.ac.at/wiki/index.php/MAGMOM.

The multipliers are multiplied together when parsing, and the value is then given as ``{'repetitions': int, 'value': int / float}``.